### PR TITLE
Show only one webcam

### DIFF
--- a/image_classification/notebooks/00_webcam.ipynb
+++ b/image_classification/notebooks/00_webcam.ipynb
@@ -46,8 +46,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Fast.ai: 1.0.47\n",
-      "Tesla V100-PCIE-16GB\n"
+      "Fast.ai: 1.0.45\n",
+      "GeForce GTX 1050\n"
      ]
     }
    ],
@@ -58,7 +58,7 @@
     "import fastai\n",
     "from fastai.vision import *\n",
     "from ipywebrtc import CameraStream, ImageRecorder\n",
-    "import ipywidgets as widgets\n",
+    "from ipywidgets import HBox, Label, Layout, Widget\n",
     "from torch.cuda import get_device_name\n",
     "from utils_ic.constants import IMAGENET_IM_SIZE\n",
     "from utils_ic.datasets import imagenet_labels, data_path\n",
@@ -162,14 +162,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Predicted label: coffee_mug\n"
+      "Predicted label: coffee_mug (conf = 0.68)\n",
+      "Took 1.5050055980682373 sec\n"
      ]
     }
    ],
    "source": [
+    "start_time = time.time()\n",
+    "\n",
     "# Use the model to predict the class label\n",
-    "_, ind, _ = learn.predict(im)\n",
-    "print(f\"Predicted label: {labels[ind]}\")"
+    "_, ind, prob = learn.predict(im)\n",
+    "print(f\"Predicted label: {labels[ind]} (conf = {prob[ind]:.2f})\")\n",
+    "\n",
+    "# Show prediction time. Note the first prediction usually takes longer because of the model loading\n",
+    "print(f\"Took {time.time()-start_time} sec\")"
    ]
   },
   {
@@ -193,29 +199,32 @@
     "        'facing_mode': 'user',\n",
     "        'audio': False,\n",
     "        'video': { 'width': IMAGENET_IM_SIZE, 'height': IMAGENET_IM_SIZE }\n",
-    "    }\n",
+    "    },\n",
+    "    layout=Layout(width=f'{IMAGENET_IM_SIZE}px')\n",
     ")\n",
     "# Image recorder for taking a snapshot\n",
-    "w_imrecorder = ImageRecorder(stream=w_cam, layout=widgets.Layout(margin='0 0 0 50px'))\n",
-    "# Text label widget to show our classification results\n",
-    "w_label = widgets.Label(\"result label\") \n",
+    "w_imrecorder = ImageRecorder(stream=w_cam, layout=Layout(padding='0 0 0 50px'))\n",
+    "# Label widget to show our classification results\n",
+    "w_label = Label(layout=Layout(padding='0 0 0 50px'))\n",
     "\n",
-    "run_model = True\n",
     "def classify_frame(_):\n",
     "    \"\"\" Classify an image snapshot by using a pretrained model\n",
     "    \"\"\"\n",
+    "    # Once capturing started, remove the capture widget since we don't need it anymore\n",
+    "    if w_imrecorder.layout.display != 'none':\n",
+    "        w_imrecorder.layout.display = 'none'\n",
+    "        \n",
     "    try:\n",
     "        im = open_image(io.BytesIO(w_imrecorder.image.value), convert_mode='RGB')\n",
-    "        _, ind, _ = learn.predict(im)\n",
-    "        # Show results to the label widget \n",
-    "        w_label.value = labels[ind]\n",
+    "        _, ind, prob = learn.predict(im)\n",
+    "        # Show result label and confidence\n",
+    "        w_label.value = f\"{labels[ind]} ({prob[ind]:.2f})\"\n",
     "    except OSError:\n",
     "        # If im_recorder doesn't have valid image data, skip it. \n",
     "        pass\n",
-    "\n",
-    "    if run_model:\n",
-    "        # Taking the next snapshot programmatically\n",
-    "        w_imrecorder.recording = True\n",
+    "    \n",
+    "    # Taking the next snapshot programmatically\n",
+    "    w_imrecorder.recording = True\n",
     "\n",
     "# Register classify_frame as a callback. Will be called whenever image.value changes. \n",
     "w_imrecorder.image.observe(classify_frame, 'value')"
@@ -231,7 +240,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2854b167ab6b4597a3d052f2fb6e1212",
+       "model_id": "",
        "version_major": 2,
        "version_minor": 0
       },
@@ -245,14 +254,14 @@
    ],
    "source": [
     "# Show widgets\n",
-    "widgets.HBox([w_cam, w_imrecorder, w_label])"
+    "HBox([w_cam, w_imrecorder, w_label])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, click the **capture button** of the image recorder widget to start classification. Labels show the most probable class predicted by the model for an image snapshot."
+    "Now, click the **capture button** of the image recorder widget to start classification. Labels show the most probable class along with the confidence predicted by the model for an image snapshot."
    ]
   },
   {
@@ -278,9 +287,15 @@
    "outputs": [],
    "source": [
     "# Stop the model and webcam \n",
-    "run_model = False\n",
-    "widgets.Widget.close_all()"
+    "Widget.close_all()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/image_classification/notebooks/00_webcam.py
+++ b/image_classification/notebooks/00_webcam.py
@@ -2,40 +2,39 @@
 # coding: utf-8
 
 # <i>Copyright (c) Microsoft Corporation. All rights reserved.</i>
-#
+# 
 # <i>Licensed under the MIT License.</i>
 
 # # WebCam Image Classification Quickstart Notebook
-#
+# 
 # <br>
-#
+# 
 # Image classification is a classical problem in computer vision that of determining whether or not the image data contains some specific object, feature, or activity. It is regarded as a mature research area
 # and currently the best models are based on [convolutional neural networks (CNNs)](https://en.wikipedia.org/wiki/Convolutional_neural_network). Such models with weights trained on millions of images and hundreds of object classes in [ImageNet dataset](http://www.image-net.org/) are available from major deep neural network frameworks such as [CNTK](https://www.microsoft.com/en-us/cognitive-toolkit/features/model-gallery/), [fast.ai](https://docs.fast.ai/vision.models.html#Computer-Vision-models-zoo), [Keras](https://keras.io/applications/), [PyTorch](https://pytorch.org/docs/stable/torchvision/models.html), and [TensorFlow](https://tfhub.dev/s?module-type=image-classification).
-#
-#
+# 
+# 
 # This notebook shows a simple example of how to load pretrained mobel and run it on a webcam stream. Here, we use [ResNet](https://arxiv.org/abs/1512.03385) model by utilizing `fastai.vision` package.
-#
+# 
 # > For more details about image classification tasks including transfer-learning (aka fine tuning), please see our [training introduction notebook](01_training_introduction.ipynb).
 
 # In[1]:
 
 
-get_ipython().run_line_magic("reload_ext", "autoreload")
-get_ipython().run_line_magic("autoreload", "2")
-get_ipython().run_line_magic("matplotlib", "inline")
+get_ipython().run_line_magic('reload_ext', 'autoreload')
+get_ipython().run_line_magic('autoreload', '2')
+get_ipython().run_line_magic('matplotlib', 'inline')
 
 
 # In[2]:
 
 
 import sys
-
 sys.path.append("../")
 import io, time, urllib.request
 import fastai
 from fastai.vision import *
 from ipywebrtc import CameraStream, ImageRecorder
-import ipywidgets as widgets
+from ipywidgets import HBox, Label, Layout, Widget
 from torch.cuda import get_device_name
 from utils_ic.constants import IMAGENET_IM_SIZE
 from utils_ic.datasets import imagenet_labels, data_path
@@ -47,13 +46,13 @@ print(get_device_name(0))
 
 
 # ## 1. Load Pretrained Model
-#
+# 
 # We use ResNet18 which is a relatively small and fast compare to other CNNs models. The [reported error rate](https://pytorch-zh.readthedocs.io/en/latest/torchvision/models.html) of the model on ImageNet is 30.24% for top-1 and 10.92% for top-5<sup>*</sup>.
-#
+# 
 # The pretrained model expects input images normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225], which is defined in `fastai.vision.imagenet_stats`.
-#
+# 
 # The output of the model is the probability distribution of the classes in ImageNet. To convert them into human-readable labels, we utilize the label json file used from [Keras](https://github.com/keras-team/keras/blob/master/keras/applications/imagenet_utils.py).
-#
+# 
 # > \* top-n: *n* labels considered most probable by the mode
 
 # In[3]:
@@ -67,12 +66,12 @@ print(f"{', '.join(labels[:5])}, ...")
 # In[4]:
 
 
-# Convert a pretrained imagenet model into Learner for prediction.
+# Convert a pretrained imagenet model into Learner for prediction. 
 learn = model_to_learner(models.resnet18(pretrained=True), IMAGENET_IM_SIZE)
 
 
 # ## 2. Classify Images
-#
+# 
 # ### 2.1 Image file
 # First, we prepare a coffee mug image to show an example of how to score a single image by using the model.
 
@@ -83,21 +82,26 @@ learn = model_to_learner(models.resnet18(pretrained=True), IMAGENET_IM_SIZE)
 IM_URL = "https://cvbp.blob.core.windows.net/public/images/cvbp_cup.jpg"
 urllib.request.urlretrieve(IM_URL, os.path.join(data_path(), "example.jpg"))
 
-im = open_image(os.path.join(data_path(), "example.jpg"), convert_mode="RGB")
+im = open_image(os.path.join(data_path(), "example.jpg"), convert_mode='RGB')
 im
 
 
 # In[6]:
 
 
+start_time = time.time()
+
 # Use the model to predict the class label
-_, ind, _ = learn.predict(im)
-print(f"Predicted label: {labels[ind]}")
+_, ind, prob = learn.predict(im)
+print(f"Predicted label: {labels[ind]} (conf = {prob[ind]:.2f})")
+
+# Show prediction time. Note the first prediction usually takes longer because of the model loading
+print(f"Took {time.time()-start_time} sec")
 
 
 # ### 2.2 WebCam Stream
-#
-# Now, let's use WebCam stream for image classification. We use `ipywebrtc` to start a webcam and get the video stream to the notebook's widget. For details about `ipywebrtc`, see [this link](https://ipywebrtc.readthedocs.io/en/latest/).
+# 
+# Now, let's use WebCam stream for image classification. We use `ipywebrtc` to start a webcam and get the video stream to the notebook's widget. For details about `ipywebrtc`, see [this link](https://ipywebrtc.readthedocs.io/en/latest/). 
 
 # In[7]:
 
@@ -105,65 +109,67 @@ print(f"Predicted label: {labels[ind]}")
 # Webcam
 w_cam = CameraStream(
     constraints={
-        "facing_mode": "user",
-        "audio": False,
-        "video": {"width": IMAGENET_IM_SIZE, "height": IMAGENET_IM_SIZE},
-    }
+        'facing_mode': 'user',
+        'audio': False,
+        'video': { 'width': IMAGENET_IM_SIZE, 'height': IMAGENET_IM_SIZE }
+    },
+    layout=Layout(width=f'{IMAGENET_IM_SIZE}px')
 )
 # Image recorder for taking a snapshot
-w_imrecorder = ImageRecorder(
-    stream=w_cam, layout=widgets.Layout(margin="0 0 0 50px")
-)
-# Text label widget to show our classification results
-w_label = widgets.Label("result label")
-
-run_model = True
-
+w_imrecorder = ImageRecorder(stream=w_cam, layout=Layout(padding='0 0 0 50px'))
+# Label widget to show our classification results
+w_label = Label(layout=Layout(padding='0 0 0 50px'))
 
 def classify_frame(_):
     """ Classify an image snapshot by using a pretrained model
     """
+    # Once capturing started, remove the capture widget since we don't need it anymore
+    if w_imrecorder.layout.display != 'none':
+        w_imrecorder.layout.display = 'none'
+        
     try:
-        im = open_image(
-            io.BytesIO(w_imrecorder.image.value), convert_mode="RGB"
-        )
-        _, ind, _ = learn.predict(im)
-        # Show results to the label widget
-        w_label.value = labels[ind]
+        im = open_image(io.BytesIO(w_imrecorder.image.value), convert_mode='RGB')
+        _, ind, prob = learn.predict(im)
+        # Show result label and confidence
+        w_label.value = f"{labels[ind]} ({prob[ind]:.2f})"
     except OSError:
-        # If im_recorder doesn't have valid image data, skip it.
+        # If im_recorder doesn't have valid image data, skip it. 
         pass
+    
+    # Taking the next snapshot programmatically
+    w_imrecorder.recording = True
 
-    if run_model:
-        # Taking the next snapshot programmatically
-        w_imrecorder.recording = True
-
-
-# Register classify_frame as a callback. Will be called whenever image.value changes.
-w_imrecorder.image.observe(classify_frame, "value")
+# Register classify_frame as a callback. Will be called whenever image.value changes. 
+w_imrecorder.image.observe(classify_frame, 'value')
 
 
 # In[8]:
 
 
 # Show widgets
-widgets.HBox([w_cam, w_imrecorder, w_label])
+HBox([w_cam, w_imrecorder, w_label])
 
 
-# Now, click the **capture button** of the image recorder widget to start classification. Labels show the most probable class predicted by the model for an image snapshot.
+# Now, click the **capture button** of the image recorder widget to start classification. Labels show the most probable class along with the confidence predicted by the model for an image snapshot.
 
 # <center>
 # <img src="https://cvbp.blob.core.windows.net/public/images/cvbp_webcam.png" style="width: 400px;"/>
 # <i>Webcam image classification example</i>
 # </center>
-#
+# 
 # <br>
-#
+# 
 # In this notebook, we have shown a quickstart example of using a pretrained model to classify images. The model, however, is not able to predict the object labels that are not part of ImageNet. From our [training introduction notebook](01_training_introduction.ipynb), you can find how to fine-tune the model to address such problems.
 
 # In[9]:
 
 
-# Stop the model and webcam
-run_model = False
-widgets.Widget.close_all()
+# Stop the model and webcam 
+Widget.close_all()
+
+
+# In[ ]:
+
+
+
+


### PR DESCRIPTION
Previous webcam notebook shows two images of webcam.
This commit hides the record widget when a user starts capturing
so that only shows one webcam image to the user.

Also display model confidence when printing out the label.