### PR TITLE
Add which_processor util

### DIFF
--- a/image_classification/notebooks/00_webcam.ipynb
+++ b/image_classification/notebooks/00_webcam.ipynb
@@ -57,7 +57,8 @@
      "output_type": "stream",
      "text": [
       "Fast.ai: 1.0.48\n",
-      "Fast.ai/Torch is using GeForce GTX 1050\n"
+      "Fast.ai (Torch) is using GPU: GeForce GTX 1050\n",
+      "Available / Total memory = 1980 / 2048 (MiB)\n"
      ]
     }
    ],
@@ -67,22 +68,21 @@
     "import io\n",
     "import time\n",
     "import urllib.request\n",
+    "\n",
     "import fastai\n",
     "from fastai.vision import *\n",
     "from ipywebrtc import CameraStream, ImageRecorder\n",
     "from ipywidgets import HBox, Label, Layout, Widget\n",
-    "import torch.cuda as cuda\n",
+    "\n",
+    "from utils_ic.common import data_path\n",
     "from utils_ic.constants import IMAGENET_IM_SIZE\n",
     "from utils_ic.datasets import imagenet_labels\n",
-    "from utils_ic.common import data_path\n",
+    "from utils_ic.gpu_utils import which_processor\n",
     "from utils_ic.imagenet_models import model_to_learner\n",
     "\n",
     "\n",
     "print(f\"Fast.ai: {fastai.__version__}\")\n",
-    "if cuda.is_available():\n",
-    "    print(f\"Fast.ai/Torch is using {cuda.get_device_name(0)}\")\n",
-    "else:\n",
-    "    print(\"Cuda is not available. Fast.ai/Torch is using CPU\")"
+    "which_processor()"
    ]
   },
   {

--- a/image_classification/notebooks/01_training_introduction.ipynb
+++ b/image_classification/notebooks/01_training_introduction.ipynb
@@ -51,7 +51,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Fast.ai version = 1.0.48\n"
+      "Fast.ai version = 1.0.48\n",
+      "Fast.ai (Torch) is using GPU: Tesla K80\n",
+      "Available / Total memory = 11430 / 11441 (MiB)\n"
      ]
     }
    ],
@@ -67,30 +69,12 @@
     "from torch.cuda import get_device_name\n",
     "# local modules\n",
     "from utils_ic.fastai_utils import TrainMetricsRecorder\n",
-    "from utils_ic.gpu_utils import gpu_info\n",
+    "from utils_ic.gpu_utils import which_processor\n",
     "from utils_ic.plot_utils import ResultsWidget, plot_pr_roc_curves\n",
     "from utils_ic.datasets import Urls, unzip_url\n",
     "\n",
-    "print(f\"Fast.ai version = {fastai.__version__}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Machine's GPU info = [{'device_name': 'Tesla K80', 'total_memory': '11441', 'used_memory': '11'}] (memory unit = MiB)\n",
-      "Fast.ai/Torch is using Tesla K80\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(f\"Machine's GPU info = {gpu_info()} (memory unit = MiB)\")\n",
-    "print(f\"Fast.ai/Torch is using {get_device_name(0)}\")"
+    "print(f\"Fast.ai version = {fastai.__version__}\")\n",
+    "which_processor()"
    ]
   },
   {
@@ -703,7 +687,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (cvbp)",
+   "display_name": "cvbp",
    "language": "python",
    "name": "cvbp"
   },

--- a/image_classification/python/00_webcam.py
+++ b/image_classification/python/00_webcam.py
@@ -2,69 +2,67 @@
 # coding: utf-8
 
 # <i>Copyright (c) Microsoft Corporation. All rights reserved.</i>
-#
+# 
 # <i>Licensed under the MIT License.</i>
 
 # # WebCam Image Classification Quickstart Notebook
-#
+# 
 # <br>
-#
+# 
 # Image classification is a classical problem in computer vision that of determining whether or not the image data contains some specific object, feature, or activity. It is regarded as a mature research area
 # and currently the best models are based on [convolutional neural networks (CNNs)](https://en.wikipedia.org/wiki/Convolutional_neural_network). Such models with weights trained on millions of images and hundreds of object classes in [ImageNet dataset](http://www.image-net.org/) are available from major deep neural network frameworks such as [CNTK](https://www.microsoft.com/en-us/cognitive-toolkit/features/model-gallery/), [fast.ai](https://docs.fast.ai/vision.models.html#Computer-Vision-models-zoo), [Keras](https://keras.io/applications/), [PyTorch](https://pytorch.org/docs/stable/torchvision/models.html), and [TensorFlow](https://tfhub.dev/s?module-type=image-classification).
-#
-#
+# 
+# 
 # This notebook shows a simple example of how to load pretrained mobel and run it on a webcam stream. Here, we use [ResNet](https://arxiv.org/abs/1512.03385) model by utilizing `fastai.vision` package.
-#
+# 
 # > For more details about image classification tasks including transfer-learning (aka fine tuning), please see our [training introduction notebook](01_training_introduction.ipynb).
 
 # ### Prerequisite
 # You will need to run this notebook on a machine with a webcam. We use `ipywebrtc` module to show the webcam widget<sup>*</sup> on the notebook. For more details about the widget, please visit ipywebrtc [github](https://github.com/maartenbreddels/ipywebrtc) or [doc](https://ipywebrtc.readthedocs.io/en/latest/).
-#
-# <sub>* Some browsers may not render & update widgets correctly. We tested this notebook works on Chrome browser.</sub>
+# 
+# <sub>* Some browsers may not render & update widgets correctly. We tested this notebook works on Chrome browser.</sub> 
 
 # In[1]:
 
 
-get_ipython().run_line_magic("reload_ext", "autoreload")
-get_ipython().run_line_magic("autoreload", "2")
-get_ipython().run_line_magic("matplotlib", "inline")
+get_ipython().run_line_magic('reload_ext', 'autoreload')
+get_ipython().run_line_magic('autoreload', '2')
+get_ipython().run_line_magic('matplotlib', 'inline')
 
 
 # In[2]:
 
 
 import sys
-
 sys.path.append("../")
 import io
 import time
 import urllib.request
+
 import fastai
 from fastai.vision import *
 from ipywebrtc import CameraStream, ImageRecorder
 from ipywidgets import HBox, Label, Layout, Widget
-import torch.cuda as cuda
+
+from utils_ic.common import data_path
 from utils_ic.constants import IMAGENET_IM_SIZE
 from utils_ic.datasets import imagenet_labels
-from utils_ic.common import data_path
+from utils_ic.gpu_utils import which_processor
 from utils_ic.imagenet_models import model_to_learner
 
 
 print(f"Fast.ai: {fastai.__version__}")
-if cuda.is_available():
-    print(f"Fast.ai/Torch is using {cuda.get_device_name(0)}")
-else:
-    print("Cuda is not available. Fast.ai/Torch is using CPU")
+which_processor()
 
 
 # ## 1. Load Pretrained Model
-#
+# 
 # We use pretrained<sup>*</sup> ResNet18 which is a relatively small and fast compare to other CNNs models. The [reported error rate](https://pytorch-zh.readthedocs.io/en/latest/torchvision/models.html) of the model on ImageNet is 30.24% for top-1 and 10.92% for top-5 (top five labels considered most probable by the mode).
-#
+# 
 # The model expects input images normalized using mean = [0.485, 0.456, 0.406] and std = [0.229, 0.224, 0.225], which is defined in `fastai.vision.imagenet_stats`.
-#
+# 
 # The output of the model is the probability distribution of the classes in ImageNet. To convert them into human-readable labels, we utilize the label json file used from [Keras](https://github.com/keras-team/keras/blob/master/keras/applications/imagenet_utils.py).
-#
+# 
 # > \* The model is pretrained on ImageNet. Note you can load your own model by using `learn = load_learner(path)` and use it. To learn more about model-export and load, see fastai [doc](https://docs.fast.ai/basic_train.html#Deploying-your-model)).
 
 # In[3]:
@@ -78,13 +76,13 @@ print(f"{', '.join(labels[:5])}, ...")
 # In[4]:
 
 
-# Convert a pretrained imagenet model into Learner for prediction.
+# Convert a pretrained imagenet model into Learner for prediction. 
 # You can load an exported model by learn = load_learner(path) as well.
 learn = model_to_learner(models.resnet18(pretrained=True), IMAGENET_IM_SIZE)
 
 
 # ## 2. Classify Images
-#
+# 
 # ### 2.1 Image file
 # First, we prepare a coffee mug image to show an example of how to score a single image by using the model.
 
@@ -95,7 +93,7 @@ learn = model_to_learner(models.resnet18(pretrained=True), IMAGENET_IM_SIZE)
 IM_URL = "https://cvbp.blob.core.windows.net/public/images/cvbp_cup.jpg"
 urllib.request.urlretrieve(IM_URL, os.path.join(data_path(), "example.jpg"))
 
-im = open_image(os.path.join(data_path(), "example.jpg"), convert_mode="RGB")
+im = open_image(os.path.join(data_path(), "example.jpg"), convert_mode='RGB')
 im
 
 
@@ -113,7 +111,7 @@ print(f"Took {time.time()-start_time} sec")
 
 
 # ### 2.2 WebCam Stream
-#
+# 
 # Now, let's use WebCam stream for image classification. We use `ipywebrtc` to start a webcam and get the video stream to the notebook's widget.
 
 # In[7]:
@@ -122,42 +120,38 @@ print(f"Took {time.time()-start_time} sec")
 # Webcam
 w_cam = CameraStream(
     constraints={
-        "facing_mode": "user",
-        "audio": False,
-        "video": {"width": IMAGENET_IM_SIZE, "height": IMAGENET_IM_SIZE},
+        'facing_mode': 'user',
+        'audio': False,
+        'video': { 'width': IMAGENET_IM_SIZE, 'height': IMAGENET_IM_SIZE }
     },
-    layout=Layout(width=f"{IMAGENET_IM_SIZE}px"),
+    layout=Layout(width=f'{IMAGENET_IM_SIZE}px')
 )
 # Image recorder for taking a snapshot
-w_imrecorder = ImageRecorder(stream=w_cam, layout=Layout(padding="0 0 0 50px"))
+w_imrecorder = ImageRecorder(stream=w_cam, layout=Layout(padding='0 0 0 50px'))
 # Label widget to show our classification results
-w_label = Label(layout=Layout(padding="0 0 0 50px"))
-
+w_label = Label(layout=Layout(padding='0 0 0 50px'))
 
 def classify_frame(_):
     """ Classify an image snapshot by using a pretrained model
     """
     # Once capturing started, remove the capture widget since we don't need it anymore
-    if w_imrecorder.layout.display != "none":
-        w_imrecorder.layout.display = "none"
-
+    if w_imrecorder.layout.display != 'none':
+        w_imrecorder.layout.display = 'none'
+        
     try:
-        im = open_image(
-            io.BytesIO(w_imrecorder.image.value), convert_mode="RGB"
-        )
+        im = open_image(io.BytesIO(w_imrecorder.image.value), convert_mode='RGB')
         _, ind, prob = learn.predict(im)
         # Show result label and confidence
         w_label.value = f"{labels[ind]} ({prob[ind]:.2f})"
     except OSError:
-        # If im_recorder doesn't have valid image data, skip it.
+        # If im_recorder doesn't have valid image data, skip it. 
         pass
-
+    
     # Taking the next snapshot programmatically
     w_imrecorder.recording = True
 
-
-# Register classify_frame as a callback. Will be called whenever image.value changes.
-w_imrecorder.image.observe(classify_frame, "value")
+# Register classify_frame as a callback. Will be called whenever image.value changes. 
+w_imrecorder.image.observe(classify_frame, 'value')
 
 
 # In[8]:
@@ -173,16 +167,20 @@ HBox([w_cam, w_imrecorder, w_label])
 # <img src="https://cvbp.blob.core.windows.net/public/images/cvbp_webcam.png" style="width: 400px;"/>
 # <i>Webcam image classification example</i>
 # </center>
-#
+# 
 # <br>
-#
+# 
 # In this notebook, we have shown a quickstart example of using a pretrained model to classify images. The model, however, is not able to predict the object labels that are not part of ImageNet. From our [training introduction notebook](01_training_introduction.ipynb), you can find how to fine-tune the model to address such problems.
 
 # In[9]:
 
 
-# Stop the model and webcam
+# Stop the model and webcam 
 Widget.close_all()
 
 
 # In[ ]:
+
+
+
+

--- a/image_classification/python/01_training_introduction.py
+++ b/image_classification/python/01_training_introduction.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 
 # <i>Copyright (c) Microsoft Corporation. All rights reserved.</i>
-#
+# 
 # <i>Licensed under the MIT License.</i>
 
 # # Introduction to Training Image Classification Models
@@ -13,9 +13,9 @@
 
 
 # Ensure edits to libraries are loaded and plotting is shown in the notebook.
-get_ipython().run_line_magic("reload_ext", "autoreload")
-get_ipython().run_line_magic("autoreload", "2")
-get_ipython().run_line_magic("matplotlib", "inline")
+get_ipython().run_line_magic('reload_ext', 'autoreload')
+get_ipython().run_line_magic('autoreload', '2')
+get_ipython().run_line_magic('matplotlib', 'inline')
 
 
 # Import fastai. For now, we'll import all (`from fastai.vision import *`) so that we can easily use different utilies provided by the fastai library.
@@ -24,31 +24,22 @@ get_ipython().run_line_magic("matplotlib", "inline")
 
 
 import sys
-
 sys.path.append("../")
 import numpy as np
 from pathlib import Path
-
 # fastai and torch
 import fastai
 from fastai.vision import *
 from fastai.metrics import accuracy
 from torch.cuda import get_device_name
-
 # local modules
 from utils_ic.fastai_utils import TrainMetricsRecorder
-from utils_ic.gpu_utils import gpu_info
+from utils_ic.gpu_utils import which_processor
 from utils_ic.plot_utils import ResultsWidget, plot_pr_roc_curves
 from utils_ic.datasets import Urls, unzip_url
 
 print(f"Fast.ai version = {fastai.__version__}")
-
-
-# In[3]:
-
-
-print(f"Machine's GPU info = {gpu_info()} (memory unit = MiB)")
-print(f"Fast.ai/Torch is using {get_device_name(0)}")
+which_processor()
 
 
 # This shows your machine's GPUs (if has any) and which computing device fastai/torch is using. The output cells here show the run results on [Azure DSVM](https://azure.microsoft.com/en-us/services/virtual-machines/data-science-virtual-machines/) Standard NC6.
@@ -58,12 +49,12 @@ print(f"Fast.ai/Torch is using {get_device_name(0)}")
 # In[4]:
 
 
-DATA_PATH = unzip_url(Urls.fridge_objects_path, exist_ok=True)
-EPOCHS = 5
+DATA_PATH     = unzip_url(Urls.fridge_objects_path, exist_ok=True)
+EPOCHS        = 5
 LEARNING_RATE = 1e-4
-IMAGE_SIZE = 299
-BATCH_SIZE = 16
-ARCHITECTURE = models.resnet50
+IMAGE_SIZE    = 299
+BATCH_SIZE    = 16
+ARCHITECTURE  = models.resnet50
 
 
 # ---
@@ -71,7 +62,7 @@ ARCHITECTURE = models.resnet50
 # ## 1. Prepare Image Classification Dataset
 
 # In this notebook, we'll use a toy dataset called *Fridge Objects*, which consists of 134 images of can, carton, milk bottle and water bottle photos taken with different backgrounds. With our helper function, the data set will be downloaded and unzip to `image_classification/data`.
-#
+# 
 # Let's set that directory to our `path` variable, which we'll use throughout the notebook, and checkout what's inside:
 
 # In[5]:
@@ -88,7 +79,7 @@ path.ls()
 # - `/can`
 
 # The most common data format for multiclass image classification is to have a folder titled the label with the images inside:
-#
+# 
 # ```
 # /images
 # +-- can (class 1)
@@ -101,26 +92,24 @@ path.ls()
 # |   +-- ...
 # +-- ...
 # ```
-#
+# 
 # and our data is already structured in that format!
 
 # ## 2. Load Images
 
 # To use fastai, we want to create `ImageDataBunch` so that the library can easily use multiple images (mini-batches) during training time. We create an ImageDataBunch by using fastai's [data_block apis](https://docs.fast.ai/data_block.html).
-#
-# For training and validation, we randomly split the data by 8:2, where 80% of the data is for training and the rest for validation.
+# 
+# For training and validation, we randomly split the data by 8:2, where 80% of the data is for training and the rest for validation. 
 
 # In[6]:
 
 
-data = (
-    ImageList.from_folder(path)
-    .split_by_rand_pct(valid_pct=0.2, seed=10)
-    .label_from_folder()
-    .transform(size=IMAGE_SIZE)
-    .databunch(bs=BATCH_SIZE)
-    .normalize(imagenet_stats)
-)
+data = (ImageList.from_folder(path) 
+        .split_by_rand_pct(valid_pct=0.2, seed=10) 
+        .label_from_folder() 
+        .transform(size=IMAGE_SIZE) 
+        .databunch(bs=BATCH_SIZE) 
+        .normalize(imagenet_stats))
 
 
 # Lets take a look at our data using the databunch we created.
@@ -128,7 +117,7 @@ data = (
 # In[7]:
 
 
-data.show_batch(rows=3, figsize=(15, 11))
+data.show_batch(rows=3, figsize=(15,11))
 
 
 # Lets see all available classes:
@@ -136,7 +125,7 @@ data.show_batch(rows=3, figsize=(15, 11))
 # In[8]:
 
 
-print(f"number of classes: {data.c}")
+print(f'number of classes: {data.c}')
 print(data.classes)
 
 
@@ -153,9 +142,9 @@ data.batch_stats
 # ## 3. Train a Model
 
 # For the model, we use a convolutional neural network (CNN). Specifically, we'll use **ResNet50** architecture. You can find more details about ResNet from [here](https://arxiv.org/abs/1512.03385).
-#
+# 
 # When training a model, there are many hypter parameters to select, such as the learning rate, the model architecture, layers to tune, and many more. With fastai, we can use the `create_cnn` function that allows us to specify the model architecture and performance indicator (metric). At this point, we already benefit from transfer learning since we download the parameters used to train on [ImageNet](http://www.image-net.org/).
-#
+# 
 # Note, we use a custom callback `TrainMetricsRecorder` to track the accuracy on the training set during training, since fast.ai's default [recorder class](https://docs.fast.ai/basic_train.html#Recorder) only supports tracking accuracy on the validation set.
 
 # In[10]:
@@ -165,7 +154,7 @@ learn = cnn_learner(
     data,
     ARCHITECTURE,
     metrics=[accuracy],
-    callback_fns=[partial(TrainMetricsRecorder, show_graph=True)],
+    callback_fns=[partial(TrainMetricsRecorder, show_graph=True)]
 )
 
 
@@ -200,7 +189,7 @@ learn.recorder.plot_losses()
 
 
 _, metric = learn.validate(learn.data.valid_dl, metrics=[accuracy])
-print(f"Accuracy on validation set: {100*float(metric):3.2f}")
+print(f'Accuracy on validation set: {100*float(metric):3.2f}')
 
 
 # Now, analyze the classification results by using `ClassificationInterpretation` module.
@@ -214,7 +203,7 @@ pred_scores = to_np(interp.probs)
 
 
 # To see details of each sample and prediction results, we use our widget helper class `ResultsWidget`. The widget shows each test image along with its ground truth label and model's prediction scores. We can use this tool to see how our model predicts each image and debug the model if needed.
-#
+# 
 # <img src="https://cvbp.blob.core.windows.net/public/images/ic_widget.png" width="600"/>
 # <center><i>Image Classification Result Widget</i></center>
 
@@ -224,7 +213,7 @@ pred_scores = to_np(interp.probs)
 w_results = ResultsWidget(
     dataset=learn.data.valid_ds,
     y_score=pred_scores,
-    y_label=[data.classes[x] for x in np.argmax(pred_scores, axis=1)],
+    y_label=[data.classes[x] for x in np.argmax(pred_scores, axis=1)]
 )
 display(w_results.show())
 
@@ -252,9 +241,13 @@ interp.plot_confusion_matrix()
 # In[19]:
 
 
-interp.plot_top_losses(9, figsize=(15, 11))
+interp.plot_top_losses(9, figsize=(15,11))
 
 
-# That's pretty much it! Now you can bring your own dataset and train your model on them easily.
+# That's pretty much it! Now you can bring your own dataset and train your model on them easily. 
 
 # In[ ]:
+
+
+
+

--- a/image_classification/tests/unit/test_gpu_utils.py
+++ b/image_classification/tests/unit/test_gpu_utils.py
@@ -2,13 +2,10 @@
 # Licensed under the MIT License.
 
 import torch.cuda as cuda
-from utils_ic.gpu_utils import gpu_info
+from utils_ic.gpu_utils import gpu_info, which_processor
 
 
 def test_gpu_info():
-    """
-    Test if exist_ok is false and (file exists, file does not exist)
-    """
     gpus = gpu_info()
     # Check if torch.cuda returns the same number of gpus
     assert cuda.device_count() == len(gpus)
@@ -18,3 +15,8 @@ def test_gpu_info():
         assert gpus[i]["device_name"] == cuda.get_device_name(i)
         # Total memory should be grater than used-memory
         assert int(gpus[i]["total_memory"]) > int(gpus[i]["used_memory"])
+
+
+def test_which_processor():
+    # Naive test: Just run the function to see whether it works or does not work
+    which_processor()

--- a/image_classification/utils_ic/gpu_utils.py
+++ b/image_classification/utils_ic/gpu_utils.py
@@ -4,6 +4,8 @@
 import subprocess
 import warnings
 
+from torch.cuda import current_device, get_device_name, is_available
+
 
 def gpu_info():
     """Get information of GPUs.
@@ -34,6 +36,17 @@ def gpu_info():
     except subprocess.CalledProcessError as e:
         warnings.warn(e.stdout)
     except FileNotFoundError:
-        warnings.warn("nvidia-smi is not available.")
+        warnings.warn("GPU info is not available.")
 
     return gpus
+
+
+def which_processor():
+    """Check if fastai/torch is using GPU or CPU"""
+    if is_available():
+        print(f"Fast.ai (Torch) is using GPU: {get_device_name(0)}")
+        gpu = gpu_info()[current_device()]
+        free = int(gpu['total_memory']) - int(gpu['used_memory'])
+        print(f"Available / Total memory = {free} / {gpu['total_memory']} (MiB)")
+    else:
+        print("Cuda is not available. Fast.ai/Torch is using CPU")


### PR DESCRIPTION
Add a gpu-util function that prints out which device (processor) fastai/torch is using:
    - if gpu, prints out the device name, available and total memory together
Update 00 and 01 notebooks to use that, replacing multiple lines of codes that call torch.cuda apis

Usage:
```
from utils_ic.gpu_utils import which_processor
which_processor()
```
Output:
> Fast.ai (Torch) is using GPU: GeForce GTX 1050
> Available / Total memory = 1980 / 2048 (MiB)

or

> Cuda is not available. Fast.ai/Torch is using CPU