### PR TITLE
Plot-utils to handle softmax out for binary-class

### DIFF
--- a/image_classification/tests/unit/test_plot_utils.py
+++ b/image_classification/tests/unit/test_plot_utils.py
@@ -10,16 +10,25 @@ from utils_ic.plot_utils import (
 )
 
 
-@pytest.fixture(scope="function")
-def binaryclass_result():
-    # Binary-class classification testcase
+@pytest.fixture(scope="module")
+def binaryclass_result_1():
+    # Binary-class classification testcase 1
     BINARY_Y_TRUE = [0, 0, 1, 1]
     BINARY_Y_SCORE = [0.1, 0.4, 0.35, 0.8]
     BINARY_CLASSES = [0, 1]
     return np.array(BINARY_Y_TRUE), np.array(BINARY_Y_SCORE), BINARY_CLASSES
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="module")
+def binaryclass_result_2():
+    # Binary-class classification testcase 2
+    BINARY_Y_TRUE = [0, 0, 1, 1]
+    BINARY_Y_SCORE = [[0.1, 0.9], [0.4, 0.6], [0.35, 0.65], [0.8, 0.2]]
+    BINARY_CLASSES = [0, 1]
+    return np.array(BINARY_Y_TRUE), np.array(BINARY_Y_SCORE), BINARY_CLASSES
+
+
+@pytest.fixture(scope="module")
 def multiclass_result():
     # Multi-class classification testcase
     MULTI_Y_TRUE = [0, 0, 1, 1, 2, 2]
@@ -35,27 +44,33 @@ def multiclass_result():
     return np.array(MULTI_Y_TRUE), np.array(MULTI_Y_SCORE), MULTI_CLASSES
 
 
-def test_plot_roc_curve(binaryclass_result, multiclass_result):
+def test_plot_roc_curve(binaryclass_result_1, binaryclass_result_2, multiclass_result):
     # Binary-class plot
-    y_true, y_score, classes = binaryclass_result
+    y_true, y_score, classes = binaryclass_result_1
+    plot_roc_curve(y_true, y_score, classes, False)
+    y_true, y_score, classes = binaryclass_result_2
     plot_roc_curve(y_true, y_score, classes, False)
     # Multi-class plot
     y_true, y_score, classes = multiclass_result
     plot_roc_curve(y_true, y_score, classes, False)
 
 
-def test_plot_precision_recall_curve(binaryclass_result, multiclass_result):
+def test_plot_precision_recall_curve(binaryclass_result_1, binaryclass_result_2, multiclass_result):
     # Binary-class plot
-    y_true, y_score, classes = binaryclass_result
+    y_true, y_score, classes = binaryclass_result_1
+    plot_precision_recall_curve(y_true, y_score, classes, False)
+    y_true, y_score, classes = binaryclass_result_2
     plot_precision_recall_curve(y_true, y_score, classes, False)
     # Multi-class plot
     y_true, y_score, classes = multiclass_result
     plot_precision_recall_curve(y_true, y_score, classes, False)
 
 
-def test_plot_pr_roc_curves(binaryclass_result, multiclass_result):
+def test_plot_pr_roc_curves(binaryclass_result_1, binaryclass_result_2, multiclass_result):
     # Binary-class plot
-    y_true, y_score, classes = binaryclass_result
+    y_true, y_score, classes = binaryclass_result_1
+    plot_pr_roc_curves(y_true, y_score, classes, False, (1, 1))
+    y_true, y_score, classes = binaryclass_result_2
     plot_pr_roc_curves(y_true, y_score, classes, False, (1, 1))
     # Multi-class plot
     y_true, y_score, classes = multiclass_result

--- a/image_classification/utils_ic/plot_utils.py
+++ b/image_classification/utils_ic/plot_utils.py
@@ -78,6 +78,11 @@ def plot_roc_curve(
 
     # Plot ROC curve
     if len(y_score.shape) == 2:
+        y_true = label_binarize(y_true, classes=list(range(len(classes))))
+        # If y_score is 2-dim on a binary-class problem, we manually convert y_true to be 2-dim
+        if y_true.shape[1] == 1:
+            y_true = np.hstack((y_true, 1 - y_true))
+
         _plot_multi_roc_curve(y_true, y_score, classes)
     else:
         _plot_roc_curve(y_true, y_score)
@@ -94,11 +99,10 @@ def plot_roc_curve(
 
 
 def _plot_multi_roc_curve(y_true, y_score, classes):
-    y_true = label_binarize(y_true, classes=list(range(len(classes))))
-
     # Plot ROC for each class
-    for i in range(len(classes)):
-        _plot_roc_curve(y_true[:, i], y_score[:, i], classes[i])
+    if len(classes) > 2:
+        for i in range(len(classes)):
+            _plot_roc_curve(y_true[:, i], y_score[:, i], classes[i])
 
     # Compute micro-average ROC curve and ROC area
     _plot_roc_curve(y_true.ravel(), y_score.ravel(), "avg")
@@ -149,6 +153,11 @@ def plot_precision_recall_curve(
     np.random.seed(123)
 
     if len(y_score.shape) == 2:
+        y_true = label_binarize(y_true, classes=list(range(len(classes))))
+        # If y_score is 2-dim on a binary-class problem, we manually convert y_true to be 2-dim
+        if y_true.shape[1] == 1:
+            y_true = np.hstack((y_true, 1 - y_true))
+
         _plot_multi_precision_recall_curve(y_true, y_score, classes)
     else:
         _plot_precision_recall_curve(
@@ -167,16 +176,15 @@ def plot_precision_recall_curve(
 
 
 def _plot_multi_precision_recall_curve(y_true, y_score, classes):
-    y_true = label_binarize(y_true, classes=list(range(len(classes))))
-
     # Plot PR for each class
-    for i in range(len(classes)):
-        _plot_precision_recall_curve(
-            y_true[:, i],
-            y_score[:, i],
-            average_precision_score(y_true[:, i], y_score[:, i]),
-            classes[i],
-        )
+    if len(classes) > 2:
+        for i in range(len(classes)):
+            _plot_precision_recall_curve(
+                y_true[:, i],
+                y_score[:, i],
+                average_precision_score(y_true[:, i], y_score[:, i]),
+                classes[i],
+            )
 
     # Plot averaged PR. A micro-average is used
     _plot_precision_recall_curve(


### PR DESCRIPTION
plot_utils' graph plot helpers couldn't handle softmax output (or two sigmoid output nodes) for binary-class.
This PR fixes that.