### PR TITLE
Update environment.yml

### DIFF
--- a/classification/environment.yml
+++ b/classification/environment.yml
@@ -32,3 +32,4 @@ dependencies:
   - ipywebrtc
   - pre-commit>=1.14.4
   - lxml>=4.3.2
+  - pyyaml>=5.1 


### PR DESCRIPTION
We need to specify the version of `pyyaml` in the env file because `yaml.FullLoader` is not supported by earlier versions of pyyaml. I guess tests were passing on our build machine because it happened to have pyyaml>=5.1, but we should enforce it.