### PR TITLE
Webcam notebook texts fix and update

### DIFF
--- a/classification/notebooks/00_webcam.ipynb
+++ b/classification/notebooks/00_webcam.ipynb
@@ -16,11 +16,11 @@
     "# Quickstart: Web Cam Image Classification\n",
     "\n",
     "\n",
-    "Image classification is the canonical computer vision task of determining if an image contains a specific object, feature, or activity. Currently, the best models are based on [convolutional neural networks (CNNs)](https://en.wikipedia.org/wiki/Convolutional_neural_network) and are typically based on the [ImageNet dataset](http://www.image-net.org/) architecture. The CNN weights are trained on millions of images and hundreds of object classes.  Implementations are available from many deep neural network frameworks including [CNTK](https://www.microsoft.com/en-us/cognitive-toolkit/features/model-gallery/), [fast.ai](https://docs.fast.ai/vision.models.html#Computer-Vision-models-zoo), [Keras](https://keras.io/applications/), [PyTorch](https://pytorch.org/docs/stable/torchvision/models.html), and [TensorFlow](https://tfhub.dev/s?module-type=image-classification).\n",
+    "Image classification is the canonical computer vision task of determining if an image contains a specific object, feature, or activity. Currently, the best models are based on [convolutional neural networks (CNNs)](https://en.wikipedia.org/wiki/Convolutional_neural_network) and are typically pre-trained on [ImageNet dataset](http://www.image-net.org/). The CNN weights are trained on millions of images and hundreds of object classes.  Implementations are available from many deep neural network frameworks including [CNTK](https://www.microsoft.com/en-us/cognitive-toolkit/features/model-gallery/), [fast.ai](https://docs.fast.ai/vision.models.html#Computer-Vision-models-zoo), [Keras](https://keras.io/applications/), [PyTorch](https://pytorch.org/docs/stable/torchvision/models.html), and [TensorFlow](https://tfhub.dev/s?module-type=image-classification).\n",
     "\n",
     "This notebook shows a simple example of loading a pretrained model to score a webcam stream. Here, we use a [ResNet](https://arxiv.org/abs/1512.03385) model using the `fastai.vision` package.\n",
     "\n",
-    "For more details about image classification tasks, including transfer-learning, please see our [training introduction notebook](01_training_introduction.ipynb)."
+    "For more details about image classification tasks, including transfer learning, please see our [training introduction notebook](01_training_introduction.ipynb)."
    ]
   },
   {
@@ -28,7 +28,15 @@
    "metadata": {},
    "source": [
     "## Prerequisite for Webcam example \n",
-    "This notebook assumes you have **a webcam** connected to your machine. We use the `ipywebrtc` module to show the webcam widget in the notebook. Currently, these widgets work on **Chrome** and **Firefox**. For more details about the widget, please visit `ipywebrtc` [github](https://github.com/maartenbreddels/ipywebrtc) or [documentation](https://ipywebrtc.readthedocs.io/en/latest/)."
+    "This notebook assumes you have **a webcam** connected to your machine. If you want to use a remote-VM to run the model and codes while using a local machine for the webcam stream, you can use an SSH tunnel:\n",
+    "1. SSH connect to your VM\n",
+    "    ```\n",
+    "    $ ssh -L 8888:localhost:8888 <user-id@url-to-your-vm>\n",
+    "    ```\n",
+    "2. Launch a Jupyter session on the VM (with port 8888 which is the default)\n",
+    "3. Open `localhost:8888` from your browser on the webcam connected local machine to access the Jupyter notebook running on the VM.\n",
+    "\n",
+    "We use the `ipywebrtc` module to show the webcam widget in the notebook. Currently, the widget works on **Chrome** and **Firefox**. For more details about the widget, please visit `ipywebrtc` [github](https://github.com/maartenbreddels/ipywebrtc) or [documentation](https://ipywebrtc.readthedocs.io/en/latest/)."
    ]
   },
   {
@@ -323,7 +331,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python (cvbp)",
+   "display_name": "cvbp",
    "language": "python",
    "name": "cvbp"
   },


### PR DESCRIPTION
#### Description
Fix webcam notebook typos and words

#### Related issue
#181

Addressing @vapaunic 's and @chenhuims' comments.

Two are not addressed by following reason:

> explain why you choose fastai after stating "This notebook shows a simple example loading pretrained model to score a webcam stream. Here, we use ResNet model using the fastai.vision package."

I personally like to have this somewhere in our repo, as people from outside may wonder about the rational while we all know we investigated different options and found fast.ai best fits to the problem.
But I think more appropriate location will be classification's README doc, not this notebook. 

> show the top few labels besides the most likely one in cell 6, since it may be interesting to see the difference between the confidence scores of the labels.

Those 'top-n labels' are presented in 01_ notebooks. I once showed top-5 classes to web-cam notebook too but was not very clean to see them on the widget (because they are refreshed every inference) so I ended up removing them and show only the top class.
