### PR TITLE
Fix Windows CPU build test errors

### DIFF
--- a/.ci/templates/unit-test-steps.yml
+++ b/.ci/templates/unit-test-steps.yml
@@ -9,7 +9,7 @@ steps:
     conda env create -f classification/environment.yml --verbose
     source activate cv
     conda env list  
-    pip install papermill lxml ipywebrtc nteract-scrapbook  # to fix error with Windows CPU target
+    pip install papermill lxml nteract-scrapbook ipywebrtc  # to fix error with Windows CPU target
   displayName: 'Create and activate conda environment'
 
 - bash: |


### PR DESCRIPTION
Adding second "pip install" call since otherwise Windows CPU target cannot find the libraries. Note that this will not slow down other targets since, if the library is already installed, pip install will not do anything.

Note that this fixes the import errors, but the tests might still run >60minutes which results in an error.