### PR TITLE
Conda env install error fix

### DIFF
--- a/classification/environment.yml
+++ b/classification/environment.yml
@@ -31,7 +31,7 @@ dependencies:
   - black>=18.6b4
   - papermill>=0.15.0
   - ipywebrtc
+  - nvidia-ml-py3
   - pre-commit>=1.14.4
   - lxml>=4.3.2
-  - pyyaml>=5.1 
   - nteract-scrapbook


### PR DESCRIPTION
This changes fix the issue #229. Tested on Linux, conda version 4.6.14
Let's see if the change works on build machines as well (old conda version as well as Windows).