### PR TITLE
Resolve test machine failure

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,8 +17,8 @@ channels:
 - fastai
 dependencies:
 - python==3.6.8
-- pytorch>=1.2.0
-- torchvision>=0.3.0
+- pytorch==1.2.0
+- torchvision==0.4.0
 - fastai==1.0.57
 - ipykernel>=4.6.1
 - jupyter>=1.0.0


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->

This may be because the latest PyTorch (version 1.3) from conda is built on CUDA 10.1 while the version on the test machine is CUDA 10.0.

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->

These days the unit test machine gave the following error message:

> RuntimeError: CUDA error: no kernel image is available for execution on the device (nms_cuda at /tmp/pip-req-build-8d3_7_rq/torchvision/csrc/cuda/nms_cuda.cu:127)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.
- [x] This PR is being made to `staging` and not `master`
