### PR TITLE
quick-fix to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ channels:
 - fastai
 dependencies:
 - python==3.6.8
-- pytorch>=1.2.0
+- pytorch==1.2.0
 - torchvision>=0.3.0
 - fastai==1.0.57
 - ipykernel>=4.6.1


### PR DESCRIPTION
fix for object detection notebooks `pytorch==1.2.0`

### Description
cuda 10.0 not working with pytorch 1.3.0 

Note - now same as `staging-branch`