### PR TITLE
Move to bare Windows GPU VMs and fix build issues

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,8 @@ channels:
 dependencies:
 - python==3.6.8
 - pytorch==1.2.0
+# pinning pillow to 6.1 to fix issue: https://github.com/python-pillow/Pillow/issues/4130
+- pillow==6.1 
 - torchvision==0.4.0
 - fastai==1.0.57
 - ipykernel>=4.6.1

--- a/environment.yml
+++ b/environment.yml
@@ -40,4 +40,4 @@ dependencies:
   - nvidia-ml-py3
   - nteract-scrapbook
   - azureml-sdk[notebooks,contrib]>=1.0.30
-  - git+https://github.com/philferriere/cocoapi.git#subdirectory=PythonAPI
+  - git+https://github.com/youngpark/cocoapi.git#subdirectory=PythonAPI

--- a/tests/.ci/azure-pipeline-windows-cpu.yml
+++ b/tests/.ci/azure-pipeline-windows-cpu.yml
@@ -20,7 +20,7 @@ jobs:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
     displayName: Add conda to PATH
   
-  - template: templates/unit-test-steps-not-linuxgpu.yml  # Template reference
+  - template: templates/unit-test-steps-windows.yml  # Template reference
 
   - script: |
      call conda env remove -n cv -y

--- a/tests/.ci/azure-pipeline-windows-cpu.yml
+++ b/tests/.ci/azure-pipeline-windows-cpu.yml
@@ -14,7 +14,7 @@ trigger:
 jobs:
 - job: WindowsCPU
   pool:
-    name: cvbpwinpool
+    name: cvbp-win-bare
 
   steps:
   - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"

--- a/tests/.ci/azure-pipeline-windows-gpu.yml
+++ b/tests/.ci/azure-pipeline-windows-gpu.yml
@@ -16,7 +16,7 @@ jobs:
     name: cvbp-win-bare
 
   steps:
-  - template: templates/unit-test-steps-not-linuxgpu.yml  # Template reference
+  - template: templates/unit-test-steps-windows.yml  # Template reference
   
   - script: |
      call conda env remove -n cv -y

--- a/tests/.ci/azure-pipeline-windows-gpu.yml
+++ b/tests/.ci/azure-pipeline-windows-gpu.yml
@@ -13,7 +13,7 @@ trigger:
 jobs:
 - job: WindowsGPU
   pool:
-    name: cvbpwinpool
+    name: cvbp-win-bare
 
   steps:
   - template: templates/unit-test-steps-not-linuxgpu.yml  # Template reference

--- a/tests/.ci/templates/unit-test-steps-windows.yml
+++ b/tests/.ci/templates/unit-test-steps-windows.yml
@@ -1,30 +1,35 @@
 # Unit and integration test steps
 steps:
 
-- powershell: |
-    Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+- powershell:
+  targetType: 'inline'
+  script: 'Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"'
   displayName: Add conda to PATH
 
-- powershell: |
-    conda remove --name cv --all --force -y
+- powershell:
+  targetType: 'inline'
+  script: 'conda remove --name cv --all --force -y'
   displayName: 'Remove conda env in case it was not created correctly'
 
-- powershell: |
-    conda env create -f environment.yml;
+- powershell:
+  targetType: 'inline'
+  script: 'conda env create -f environment.yml;
     source activate cv;
-    conda env list;
+    conda env list;'
   displayName: 'Create and activate conda environment'
 
-- powershell: |
-    source activate cv;
-    pytest --durations 100 tests --junitxml=junit/test-unitttest.xml -m "not azuremlnotebooks and not linuxgpu"
+- powershell:
+  targetType: 'inline'
+  script: 'source activate cv;
+    pytest --durations 100 tests --junitxml=junit/test-unitttest.xml -m "not azuremlnotebooks and not linuxgpu"'
   displayName: 'Run unit and (only on Linux GPU) integration tests'
 
-- powershell: |
-      echo Remove Conda Environment;
+- powershell:
+  targetType: 'inline'
+  script: 'echo Remove Conda Environment;
       conda remove -n cv --all -q --force -y;
       conda env list;
-      echo Done Cleanup;
+      echo Done Cleanup;'
   displayName: 'Cleanup Task'
   condition: always()
 

--- a/tests/.ci/templates/unit-test-steps-windows.yml
+++ b/tests/.ci/templates/unit-test-steps-windows.yml
@@ -10,22 +10,21 @@ steps:
   displayName: 'Remove conda env in case it was not created correctly'
 
 - powershell: |
-    conda env create -f environment.yml
-    source activate cv
-    conda env list
+    conda env create -f environment.yml;
+    source activate cv;
+    conda env list;
   displayName: 'Create and activate conda environment'
 
 - powershell: |
-    source activate cv
-    # python -m ipykernel install --user --name cv --display-name "cv"
+    source activate cv;
     pytest --durations 100 tests --junitxml=junit/test-unitttest.xml -m "not azuremlnotebooks and not linuxgpu"
   displayName: 'Run unit and (only on Linux GPU) integration tests'
 
 - powershell: |
-      echo Remove Conda Environment
-      conda remove -n cv --all -q --force -y
-      conda env list
-      echo Done Cleanup
+      echo Remove Conda Environment;
+      conda remove -n cv --all -q --force -y;
+      conda env list;
+      echo Done Cleanup;
   displayName: 'Cleanup Task'
   condition: always()
 

--- a/tests/.ci/templates/unit-test-steps-windows.yml
+++ b/tests/.ci/templates/unit-test-steps-windows.yml
@@ -1,0 +1,36 @@
+# Unit and integration test steps
+steps:
+
+- powershell: |
+    conda remove --name cv --all --force -y
+  displayName: 'Remove conda env in case it was not created correctly'
+
+- powershell: |
+    conda env create -f environment.yml
+    source activate cv
+    conda env list
+  displayName: 'Create and activate conda environment'
+
+- powershell: |
+    source activate cv
+    # python -m ipykernel install --user --name cv --display-name "cv"
+    pytest --durations 100 tests --junitxml=junit/test-unitttest.xml -m "not azuremlnotebooks and not linuxgpu"
+  displayName: 'Run unit and (only on Linux GPU) integration tests'
+
+- powershell: |
+      conda remove -n cv --all -q --force -y
+      conda env list
+  displayName: 'Clean up the new conda environment'
+  condition: always()
+
+- task: PublishTestResults@2
+  inputs:
+    testResultsFiles: '**/test-unitttest.xml'
+    testRunTitle: 'Test results for PyTest'
+
+- task: ComponentGovernanceComponentDetection@0
+  inputs:
+    scanType: 'Register'
+    verbosity: 'Verbose'
+    alertWarningLevel: 'High'
+

--- a/tests/.ci/templates/unit-test-steps-windows.yml
+++ b/tests/.ci/templates/unit-test-steps-windows.yml
@@ -1,32 +1,27 @@
 # Unit and integration test steps
 steps:
 
-- powershell:
-  targetType: 'inline'
-  script: 'Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"'
+- powershell: |
+    Write-Host '##vso[task.prependpath]$env:CONDA\Scripts'
   displayName: Add conda to PATH
 
-- powershell:
-  targetType: 'inline'
-  script: 'conda remove --name cv --all --force -y'
+- powershell: |
+    Invoke-Expression -Command 'conda remove --name cv --all --force -y'
   displayName: 'Remove conda env in case it was not created correctly'
 
-- powershell:
-  targetType: 'inline'
-  script: 'conda env create -f environment.yml;
+- powershell: |
+    Invoke-Expression -Command 'conda env create -f environment.yml;
     source activate cv;
     conda env list;'
   displayName: 'Create and activate conda environment'
 
-- powershell:
-  targetType: 'inline'
-  script: 'source activate cv;
+- powershell: |
+    Invoke-Expression -Command 'source activate cv;
     pytest --durations 100 tests --junitxml=junit/test-unitttest.xml -m "not azuremlnotebooks and not linuxgpu"'
   displayName: 'Run unit and (only on Linux GPU) integration tests'
 
-- powershell:
-  targetType: 'inline'
-  script: 'echo Remove Conda Environment;
+- powershell: |
+    Invoke-Expression -Command 'echo Remove Conda Environment;
       conda remove -n cv --all -q --force -y;
       conda env list;
       echo Done Cleanup;'

--- a/tests/.ci/templates/unit-test-steps-windows.yml
+++ b/tests/.ci/templates/unit-test-steps-windows.yml
@@ -5,32 +5,32 @@ steps:
     Write-Host '##vso[task.prependpath]$env:CONDA\Scripts'
   displayName: Add conda to PATH
 
-- powershell: |
-    Invoke-Expression -Command 'conda remove --name cv --all --force -y'
+- script: |
+    conda remove --name cv --all --force -y
   displayName: 'Remove conda env in case it was not created correctly'
 
-- powershell: |
-    Invoke-Expression -Command 'conda env create -f environment.yml'
+- script: |
+    conda env create -f environment.yml
   displayName: 'Create and activate conda environment'
 
-- powershell: |
-    Invoke-Expression -Command 'conda env list'
+- script: |
+    conda env list
   displayName: 'List conda environments to ensure one was created'
 
-- powershell: |
-    Invoke-Expression -Command 'call activate cv'
-    Invoke-Expression -Command 'pytest --durations 100 tests --junitxml=junit/test-unitttest.xml -m "not azuremlnotebooks and not linuxgpu"'
+- script: |
+    call activate cv
+    pytest --durations 100 tests --junitxml=junit/test-unitttest.xml -m "not azuremlnotebooks and not linuxgpu"
   displayName: 'Run unit and (only on Linux GPU) integration tests'
 
-- powershell: |
-    Invoke-Expression -Command 'echo Remove Conda Environment'
-    Invoke-Expression -Command 'conda remove -n cv --all -q --force -y'
-    Invoke-Expression -Command 'echo Done Cleanup'
+- script: |
+    echo Remove Conda Environment
+    conda remove -n cv --all -q --force -y
+    echo Done Cleanup
   displayName: 'Clean up the newly created environment'
   condition: always()
 
-- powershell: |
-    Invoke-Expression -Command 'conda env list'
+- script: |
+    conda env list
   displayName: 'List conda environments to verify cleanup of the new environment'
 
 - task: PublishTestResults@2

--- a/tests/.ci/templates/unit-test-steps-windows.yml
+++ b/tests/.ci/templates/unit-test-steps-windows.yml
@@ -2,8 +2,8 @@
 steps:
 
 - powershell: |
-    conda init powershell
-  displayName: 'Initialize Conda for use with powershell'
+    Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+  displayName: Add conda to PATH
 
 - powershell: |
     conda remove --name cv --all --force -y

--- a/tests/.ci/templates/unit-test-steps-windows.yml
+++ b/tests/.ci/templates/unit-test-steps-windows.yml
@@ -11,7 +11,6 @@ steps:
 
 - powershell: |
     Invoke-Expression -Command 'conda env create -f environment.yml'
-    Invoke-Expression -Command 'source activate cv'
   displayName: 'Create and activate conda environment'
 
 - powershell: |
@@ -19,7 +18,7 @@ steps:
   displayName: 'List conda environments to ensure one was created'
 
 - powershell: |
-    Invoke-Expression -Command 'source activate cv'
+    Invoke-Expression -Command 'call activate cv'
     Invoke-Expression -Command 'pytest --durations 100 tests --junitxml=junit/test-unitttest.xml -m "not azuremlnotebooks and not linuxgpu"'
   displayName: 'Run unit and (only on Linux GPU) integration tests'
 

--- a/tests/.ci/templates/unit-test-steps-windows.yml
+++ b/tests/.ci/templates/unit-test-steps-windows.yml
@@ -11,13 +11,13 @@ steps:
 
 - powershell: |
     Invoke-Expression -Command 'conda env create -f environment.yml;
-    source activate cv;
-    conda env list;'
+      source activate cv;
+      conda env list;'
   displayName: 'Create and activate conda environment'
 
 - powershell: |
     Invoke-Expression -Command 'source activate cv;
-    pytest --durations 100 tests --junitxml=junit/test-unitttest.xml -m "not azuremlnotebooks and not linuxgpu"'
+      pytest --durations 100 tests --junitxml=junit/test-unitttest.xml -m "not azuremlnotebooks and not linuxgpu"'
   displayName: 'Run unit and (only on Linux GPU) integration tests'
 
 - powershell: |

--- a/tests/.ci/templates/unit-test-steps-windows.yml
+++ b/tests/.ci/templates/unit-test-steps-windows.yml
@@ -2,6 +2,10 @@
 steps:
 
 - powershell: |
+    conda init powershell
+  displayName: 'Initialize Conda for use with powershell'
+
+- powershell: |
     conda remove --name cv --all --force -y
   displayName: 'Remove conda env in case it was not created correctly'
 
@@ -18,9 +22,11 @@ steps:
   displayName: 'Run unit and (only on Linux GPU) integration tests'
 
 - powershell: |
+      echo Remove Conda Environment
       conda remove -n cv --all -q --force -y
       conda env list
-  displayName: 'Clean up the new conda environment'
+      echo Done Cleanup
+  displayName: 'Cleanup Task'
   condition: always()
 
 - task: PublishTestResults@2

--- a/tests/.ci/templates/unit-test-steps-windows.yml
+++ b/tests/.ci/templates/unit-test-steps-windows.yml
@@ -10,23 +10,29 @@ steps:
   displayName: 'Remove conda env in case it was not created correctly'
 
 - powershell: |
-    Invoke-Expression -Command 'conda env create -f environment.yml;
-      source activate cv;
-      conda env list;'
+    Invoke-Expression -Command 'conda env create -f environment.yml'
+    Invoke-Expression -Command 'source activate cv'
   displayName: 'Create and activate conda environment'
 
 - powershell: |
-    Invoke-Expression -Command 'source activate cv;
-      pytest --durations 100 tests --junitxml=junit/test-unitttest.xml -m "not azuremlnotebooks and not linuxgpu"'
+    Invoke-Expression -Command 'conda env list'
+  displayName: 'List conda environments to ensure one was created'
+
+- powershell: |
+    Invoke-Expression -Command 'source activate cv'
+    Invoke-Expression -Command 'pytest --durations 100 tests --junitxml=junit/test-unitttest.xml -m "not azuremlnotebooks and not linuxgpu"'
   displayName: 'Run unit and (only on Linux GPU) integration tests'
 
 - powershell: |
-    Invoke-Expression -Command 'echo Remove Conda Environment;
-      conda remove -n cv --all -q --force -y;
-      conda env list;
-      echo Done Cleanup;'
-  displayName: 'Cleanup Task'
+    Invoke-Expression -Command 'echo Remove Conda Environment'
+    Invoke-Expression -Command 'conda remove -n cv --all -q --force -y'
+    Invoke-Expression -Command 'echo Done Cleanup'
+  displayName: 'Clean up the newly created environment'
   condition: always()
+
+- powershell: |
+    Invoke-Expression -Command 'conda env list'
+  displayName: 'List conda environments to verify cleanup of the new environment'
 
 - task: PublishTestResults@2
   inputs:

--- a/utils_cv/detection/plot.py
+++ b/utils_cv/detection/plot.py
@@ -379,7 +379,7 @@ def _plot_pr_curve_iou_range(
     x = np.arange(0.0, 1.01, 0.01)
     iou_thrs_idx = range(0, 10)
     iou_thrs = np.linspace(
-        0.5, 0.95, np.round((0.95 - 0.5) / 0.05) + 1, endpoint=True
+        0.5, 0.95, int(np.round((0.95 - 0.5) / 0.05)) + 1, endpoint=True
     )
 
     # get_cmap() - a function that maps each index in 0, 1, ..., n-1 to a distinct


### PR DESCRIPTION
### Description
This PR addresses the following issues:
- Lack of stability on the Windows build/test infrastructure
    - Fix: 
        - Move the test infrastructure to use bare Windows GPU VMs
        - Add a Azure DevOps pipeline yaml file specifically for Windows
- ImportError: cannot import name 'PILLOW_VERSION' from 'PIL' (unknown location)
    - Fix: 
        - Pin the version of pillow to 6.1
        - Relevant issue/discussion: [https://github.com/python-pillow/Pillow/issues/4130](https://github.com/python-pillow/Pillow/issues/4130)
- TypeError: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer.
    - Fix:
        - We need to use a fork of the cocodataset/cocoapi to support windows builds, so we have the option of choosing between a) pinning numpy < 1.18 or b) or taking the fix from commit: https://github.com/cocodataset/cocoapi/commit/6c3b394
        - Pinning the version of numpy is only a temporary hack as numpy stopped accepting a floating point value in `numpy.linspace()` since version 1.12 and will not be supported in future releases.
        - Hence, I created a PR to the fork with the required changes: https://github.com/philferriere/cocoapi/pull/9
        - Since it looks like the fork isn't being actively maintained, so I updated the `environment.yml` file to use a different fork that has the changes merged to unblock us for now.
        - Also added the required fix to `utils_cv/detection/plot.py` as well.

### Related Issues
[[BUG] Error occurred: User program failed with TypeError: object of type <class 'numpy.float64'> cannot be safely interpreted as an integer](https://github.com/microsoft/computervision-recipes/issues/462)


### Checklist:
- [X] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [X] This PR is being made to `staging` and not `master`
