### PR TITLE
Update usage of deprecated field in test_classification_parameter_sweeper.py

### DIFF
--- a/tests/unit/classification/test_classification_parameter_sweeper.py
+++ b/tests/unit/classification/test_classification_parameter_sweeper.py
@@ -19,10 +19,10 @@ def _test_sweeper_run(df: pd.DataFrame, df_length: int):
     # assert len
     assert len(df) == df_length
     # assert df is a multi-index dataframe
-    assert isinstance(df.index, pd.core.index.MultiIndex)
+    assert isinstance(df.index, pd.MultiIndex)
     # assert clean_df works
     df = clean_sweeper_df(df)
-    assert isinstance(df.index, pd.core.index.MultiIndex)
+    assert isinstance(df.index, pd.MultiIndex)
     # assert no error when calling plot_df function
     plot_sweeper_df(df)
 


### PR DESCRIPTION
### Description
With the new release of pandas 1.0.0 on January 29th (https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.0.0.html), `pandas.core.index` has been deprecated.

Updated the usage of deprecated field in `test_classification_parameter_sweeper.py` to fix our unit tests that are now failing due to the deprecation.

### Related Issues
https://github.com/microsoft/computervision-recipes/issues/478


### Checklist:
- [X] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [X] This PR is being made to `staging` and not `master`
