### PR TITLE
Support Binder environment

### DIFF
--- a/tests/unit/common/test_common_gpu.py
+++ b/tests/unit/common/test_common_gpu.py
@@ -4,6 +4,7 @@
 from utils_cv.common.gpu import (
     db_num_workers,
     linux_with_gpu,
+    is_binder,
     is_linux,
     is_windows,
     which_processor,
@@ -25,6 +26,10 @@ def test_is_windows():
 
 def test_linux_with_gpu():
     assert type(linux_with_gpu()) == bool
+
+
+def test_is_binder():
+    assert is_binder() == False
 
 
 def test_db_num_workers():

--- a/utils_cv/common/gpu.py
+++ b/utils_cv/common/gpu.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+import os
 import platform
 
 import torch
@@ -32,6 +33,11 @@ def linux_with_gpu():
     return is_linux() and has_gpu
 
 
+def is_binder():
+    """Returns if machine is running within a Binder environment"""
+    return "BINDER_REPO_URL" in os.environ
+
+
 def torch_device():
     """ Gets the torch device. Try gpu first, otherwise gpu. """
     return (
@@ -44,11 +50,11 @@ def torch_device():
 def db_num_workers(non_windows_num_workers: int = 16):
     """Returns how many workers to use when loading images in a databunch. On windows machines using >0 works significantly slows down model
     training and evaluation. Setting num_workers to zero on Windows machines will speed up training/inference significantly, but will still be
-    2-3 times slower.
+    2-3 times slower. Additionally, also set num_workers to zero if running within Binder to avoid an error being thrown. 
 
     For a description of the slow windows speed see: https://github.com/pytorch/pytorch/issues/12831
     """
-    if is_windows():
+    if is_windows() or is_binder():
         return 0
     else:
         return non_windows_num_workers


### PR DESCRIPTION
### Description
Set number of image reader workers to zero if running within a Binder environment. Otherweise Binder throws an error.

### Checklist:
- [x] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [x] I have added tests covering my contributions.
- [x] I have updated the documentation accordingly.
- [x] This PR is being made to `staging` and not `master`
