### PR TITLE
Add more steps to ensure a clean conda environment build

### DIFF
--- a/tests/.ci/azure-pipeline-windows-cpu.yml
+++ b/tests/.ci/azure-pipeline-windows-cpu.yml
@@ -17,18 +17,7 @@ jobs:
     name: cvbp-win-bare
 
   steps:
-  - powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
-    displayName: Add conda to PATH
-  
   - template: templates/unit-test-steps-windows.yml  # Template reference
-
-  - script: |
-     call conda env remove -n cv -y
-     if exist C:\Anaconda\envs\cv rmdir /s /q C:\Anaconda\envs\cv
-
-    workingDirectory: tests
-    displayName: 'Conda remove'
-    timeoutInMinutes: 10
 
   - script: |
      del /q /S %LOCALAPPDATA%\Temp\*

--- a/tests/.ci/azure-pipeline-windows-gpu.yml
+++ b/tests/.ci/azure-pipeline-windows-gpu.yml
@@ -17,14 +17,6 @@ jobs:
 
   steps:
   - template: templates/unit-test-steps-windows.yml  # Template reference
-  
-  - script: |
-     call conda env remove -n cv -y
-     if exist C:\Anaconda\envs\cv rmdir /s /q C:\Anaconda\envs\cv
-
-    workingDirectory: tests
-    displayName: 'Conda remove'
-    timeoutInMinutes: 10
 
   - script: |
      del /q /S %LOCALAPPDATA%\Temp\*

--- a/tests/.ci/templates/unit-test-steps-windows.yml
+++ b/tests/.ci/templates/unit-test-steps-windows.yml
@@ -30,6 +30,16 @@ steps:
   condition: always()
 
 - script: |
+    IF EXIST C:\ProgramData\Miniconda3\envs\cv (
+      echo Removing conda environment directory...
+      rmdir /s /q C:\ProgramData\Miniconda3\envs\cv
+    ) ELSE (
+      echo Conda environment directory is clean.
+    )
+  displayName: 'Ensure conda environment directory is clean'
+  condition: always()
+
+- script: |
     conda env list
   displayName: 'List conda environments to verify cleanup of the new environment'
 


### PR DESCRIPTION
### Description
Added more steps in the build/test pipelines to ensure that the conda environments used for tests are built from a clean slate to prevent prior builds' artifacts from impacting future builds.

### Related Issues
[We should guarantee that conda environments are built from a clean slate](https://github.com/microsoft/computervision-recipes/issues/495)

### Checklist:
- [X] I have followed the [contribution guidelines](../CONTRIBUTING.md) and code style for this project.
- [ ] I have added tests covering my contributions.
- [ ] I have updated the documentation accordingly.
- [X] This PR is being made to `staging` and not `master`
- [X] I will squash merge this PR into `staging`
